### PR TITLE
Update to reflect Tyk Version 2.0, Dashboard 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ Install and configure Tyk API gateway (https://tyk.io)
 ## Usage
 
 - For a testing installation, just add the `tyk::default` recipe to your 
-runlist. It will install Redis, Mongo, Tyk Gateway and Tyk Dashboard on the
-node. You have to bootstrap the dashboard with an initial user, as per manual.
+runlist. It will install Redis, Mongo, Tyk Gateway, Tyk Dashboard and Tyk Pump
+on the node. You have to bootstrap the dashboard with an initial user, as per
+manual.
 After that, point your browser to your node port 3000 and the dashboard
 should come up and let you login with the user you created during the
 bootstrap.
-- For production, use the provided `install_gateway` and `install_dashboard`
-recipes. You will want to change the configuration attributes. Best solution
-is to create your own wrapper cookbook, where you set the `default` attributes.
+- For production, use the provided `install_gateway`, `install_dashboard` and
+`install_pump` recipes. You will want to change the configuration attributes.
+Best solution is to create your own wrapper cookbook, where you set the
+`default` attributes.
 
 ## Contributing
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,7 +59,7 @@ default['tyk']['dashboard']['install_path'] = '/opt/tyk-dashboard'
 # For documentation see https://tyk.io/docs/tyk-dashboard-v1-0/configuration/
 default['tyk']['dashboard']['config']['listen_port'] = 3000
 default['tyk']['dashboard']['config']['tyk_api_config']['Host'] = "localhost"
-default['tyk']['dashboard']['config']['tyk_api_config']['Port'] = #{node['tyk']['gateway']['config']['listen_port']}
+default['tyk']['dashboard']['config']['tyk_api_config']['Port'] = "#{node['tyk']['gateway']['config']['listen_port']}"
 default['tyk']['dashboard']['config']['tyk_api_config']['Secret'] = node['tyk']['gateway']['config']['secret']
 default['tyk']['dashboard']['config']['mongo_url'] = node['tyk']['gateway']['config']['analytics_config']['mongo_url']
 default['tyk']['dashboard']['config']['shared_node_secret'] = node['tyk']['gateway']['config']['secret']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,12 +3,12 @@ default['tyk']['gateway']['install_path'] = '/opt/tyk-gateway'
 
 # Gateway configuration
 # The configuration file is generated from node['tyk']['gateway']['config']
-# For documentation see https://tyk.io/v1.9/configuration/configuration/
+# For documentation see https://tyk.io/docs/tyk-api-gateway-v-2-0/configuration/gateway-configuration-options/
 default['tyk']['gateway']['config']['listen_port'] = 8080
 default['tyk']['gateway']['config']['secret'] = "Y0uSh0u1dR3a11yChang3Th1sS3cr3t"
 default['tyk']['gateway']['config']['template_path'] = "#{node['tyk']['gateway']['install_path']}/templates"
 default['tyk']['gateway']['config']['tyk_js_path'] = "#{node['tyk']['gateway']['install_path']}/js/tyk.js"
-default['tyk']['gateway']['config']['use_db_app_configs'] = true
+default['tyk']['gateway']['config']['use_db_app_configs'] = false
 default['tyk']['gateway']['config']['app_path'] = "#{node['tyk']['gateway']['install_path']}/apps"
 default['tyk']['gateway']['config']['middleware_path'] = "#{node['tyk']['gateway']['install_path']}/middleware"
 default['tyk']['gateway']['config']['storage']
@@ -19,32 +19,50 @@ default['tyk']['gateway']['config']['storage']['username'] = ""
 default['tyk']['gateway']['config']['storage']['password'] = ""
 default['tyk']['gateway']['config']['storage']['database'] = 0
 default['tyk']['gateway']['config']['storage']['optimisation_max_idle'] = 500
-default['tyk']['gateway']['config']['enable_analytics'] = true
-default['tyk']['gateway']['config']['analytics_config']['type'] = "mongo"
-default['tyk']['gateway']['config']['analytics_config']['mongo_url'] = "mongodb://127.0.0.1:27017/tyk_analytics"
-default['tyk']['gateway']['config']['analytics_config']['mongo_collection'] = "tyk_analytics"
-default['tyk']['gateway']['config']['analytics_config']['purge_delay'] = 5
+default['tyk']['gateway']['config']['storage']['optimisation_max_active'] = 800
+default['tyk']['gateway']['config']['enable_analytics'] = false
+default['tyk']['gateway']['config']['analytics_config']['type'] = "csv"
+default['tyk']['gateway']['config']['analytics_config']['csv_dir'] = "/tmp"
+default['tyk']['gateway']['config']['analytics_config']['mongo_url'] = ""
+default['tyk']['gateway']['config']['analytics_config']['mongo_collection'] = ""
+default['tyk']['gateway']['config']['analytics_config']['purge_delay'] = -1
 default['tyk']['gateway']['config']['analytics_config']['ignored_ips'] = []
+default['tyk']['gateway']['config']['health_check']
 default['tyk']['gateway']['config']['health_check']['enable_health_checks'] = true
 default['tyk']['gateway']['config']['health_check']['health_check_value_timeouts'] = 60
 default['tyk']['gateway']['config']['optimisations_use_async_session_write'] = true
 default['tyk']['gateway']['config']['allow_master_keys'] = false
-default['tyk']['gateway']['config']['policies']['policy_source'] = "mongo"
-default['tyk']['gateway']['config']['policies']['policy_record_name'] = "tyk_policies"
+default['tyk']['gateway']['config']['policies']
+default['tyk']['gateway']['config']['policies']['policy_source'] = "file"
+default['tyk']['gateway']['config']['policies']['policy_record_name'] = "policies"
 default['tyk']['gateway']['config']['hash_keys'] = true
 default['tyk']['gateway']['config']['suppress_redis_signal_reload'] = false
+default['tyk']['gateway']['config']['close_connections'] = true
+default['tyk']['gateway']['config']['local_session_cache']
+default['tyk']['gateway']['config']['local_session_cache']['disable_cached_session_state'] = true
+default['tyk']['gateway']['config']['uptime_tests']
+default['tyk']['gateway']['config']['uptime_tests']['disable'] = false
+default['tyk']['gateway']['config']['uptime_tests']['config']
+default['tyk']['gateway']['config']['uptime_tests']['config']['enable_uptime_analytics'] = false
+default['tyk']['gateway']['config']['uptime_tests']['config']['failure_trigger_sample_size'] = 3
+default['tyk']['gateway']['config']['uptime_tests']['config']['time_wait'] = 300
+default['tyk']['gateway']['config']['uptime_tests']['config']['checker_pool_size'] = 50
+default['tyk']['gateway']['config']['hostname'] = "tyk.local"
+default['tyk']['gateway']['config']['enable_custom_domains'] = true
+default['tyk']['gateway']['config']['enable_jsvm'] = true
 
 # Dashboard
 default['tyk']['dashboard']['install_path'] = '/opt/tyk-dashboard'
-  
-# Dashboard configuration  
+
+# Dashboard configuration
 # The configuration file is generated from node['tyk']['dashboard']['config']
-# For documentation see https://tyk.io/v1.9/configuration/dashboard-config/
+# For documentation see https://tyk.io/docs/tyk-dashboard-v1-0/configuration/
 default['tyk']['dashboard']['config']['listen_port'] = 3000
-default['tyk']['dashboard']['config']['tyk_api_config']['Host'] = "http://localhost"
-default['tyk']['dashboard']['config']['tyk_api_config']['Port'] = "#{node['tyk']['gateway']['config']['listen_port']}"
+default['tyk']['dashboard']['config']['tyk_api_config']['Host'] = "localhost"
+default['tyk']['dashboard']['config']['tyk_api_config']['Port'] = #{node['tyk']['gateway']['config']['listen_port']}
 default['tyk']['dashboard']['config']['tyk_api_config']['Secret'] = node['tyk']['gateway']['config']['secret']
 default['tyk']['dashboard']['config']['mongo_url'] = node['tyk']['gateway']['config']['analytics_config']['mongo_url']
+default['tyk']['dashboard']['config']['shared_node_secret'] = node['tyk']['gateway']['config']['secret']
 default['tyk']['dashboard']['config']['page_size'] = 10
 default['tyk']['dashboard']['config']['admin_secret'] = "12345"
 default['tyk']['dashboard']['config']['redis_port'] = 6379
@@ -75,3 +93,4 @@ default['tyk']['dashboard']['config']['ui']['uptime'] = {}
 default['tyk']['dashboard']['config']['ui']['portal'] = {}
 default['tyk']['dashboard']['config']['ui']['designer'] = {}
 default['tyk']['dashboard']['config']['home_dir'] = node['tyk']['dashboard']['install_path']
+default['tyk']['dashboard']['config']['identity_broker']['enabled'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -94,3 +94,25 @@ default['tyk']['dashboard']['config']['ui']['portal'] = {}
 default['tyk']['dashboard']['config']['ui']['designer'] = {}
 default['tyk']['dashboard']['config']['home_dir'] = node['tyk']['dashboard']['install_path']
 default['tyk']['dashboard']['config']['identity_broker']['enabled'] = false
+
+# Pump
+default['tyk']['pump']['install_path'] = '/opt/tyk-pump'
+
+# Pump configuration
+# The configuration file is generated from node['tyk']['pump']['config']
+# For documentation see https://tyk.io/docs/tyk-pump/configuration/
+default['tyk']['pump']['config']['analytics_storage_type'] = "redis"
+default['tyk']['pump']['config']['analytics_storage_config']['type'] = "redis"
+default['tyk']['pump']['config']['analytics_storage_config']['host'] = "localhost"
+default['tyk']['pump']['config']['analytics_storage_config']['port'] = 6379
+default['tyk']['pump']['config']['analytics_storage_config']['hosts'] = nil
+default['tyk']['pump']['config']['analytics_storage_config']['username'] = ""
+default['tyk']['pump']['config']['analytics_storage_config']['password'] = ""
+default['tyk']['pump']['config']['analytics_storage_config']['database'] = 0
+default['tyk']['pump']['config']['analytics_storage_config']['optimisation_max_idle'] = 100
+default['tyk']['pump']['config']['analytics_storage_config']['optimisation_max_active'] = 0
+default['tyk']['pump']['config']['analytics_storage_config']['enable_cluster'] = false
+default['tyk']['pump']['config']['purge_delay'] = 10
+default['tyk']['pump']['config']['uptime_pump_config']['collection_name'] = 'tyk_uptime_analytics'
+default['tyk']['pump']['config']['uptime_pump_config']['mongo_url'] = 'mongodb://localhost/tyk_analytics'
+default['tyk']['pump']['config']['dont_purge_uptime_data'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'michal@taborsky.cz'
 license          'Apache 2.0'
 description      'Installs/Configures tyk'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.1.3'
 
 %w[ debian ubuntu centos redhat fedora scientific oracle ].each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,4 +9,5 @@ include_recipe 'redisio::enable'
 include_recipe 'mongodb'
 include_recipe 'tyk::install_gateway'
 include_recipe 'tyk::install_dashboard'
+include_recipe 'tyk::install_pump'
 

--- a/recipes/install_pump.rb
+++ b/recipes/install_pump.rb
@@ -1,0 +1,16 @@
+packagecloud_repo 'tyk/tyk-pump'
+
+package 'tyk-pump'
+
+template '/opt/tyk-pump/pump.conf' do
+  source 'tyk.conf.erb'
+  variables(
+    :config => node['tyk']['pump']['config']
+  )
+  notifies :restart, "service[tyk-pump]"
+end
+
+service 'tyk-pump' do
+  action [:enable, :start]
+  supports restart: true, reload: false, status: true
+end

--- a/test/integration/default/serverspec/pump_spec.rb
+++ b/test/integration/default/serverspec/pump_spec.rb
@@ -1,0 +1,8 @@
+require 'serverspec'
+set :backend, :exec
+
+describe "tyk-pump" do
+  it "has a service running" do
+    expect(service("tyk-pump")).to be_running
+  end
+end


### PR DESCRIPTION
The config has changed a bit with Tyk 2.0, and a new Pump service has been added.

Using the scripts mentioned in https://tyk.io/docs/tyk-api-gateway-v-2-0/installation-options-setup/install-tyk-pro-edition-on-ubuntu/, updated default attributes to reflect what happens when no arguments are supplied to the various setup.sh commands.

A simple test-kitchen entry has been added for the new pump service.
